### PR TITLE
feat : 반응형 미니바 구현 완성 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-// import { Outlet } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 import theme from "Styles/theme";
 
@@ -11,9 +10,6 @@ const App = () => {
 			<ThemeProvider theme={theme}>
 				<GlobalStyle />
 				<Router />
-
-				{/* <Outlet /> */}
-				{/* 추후 Main part 생성 후 적용 */}
 			</ThemeProvider>
 		</div>
 	);

--- a/src/Component/Header/GNB/GNB.tsx
+++ b/src/Component/Header/GNB/GNB.tsx
@@ -27,14 +27,14 @@ const GNBNavLists = ({ listItems }: GNBNavPropsType) => {
 interface IGNBProps {
 	isLocationSearch: boolean;
 	miniBarIsClicked: boolean;
-	miniSearchBarIsHidden: boolean;
+	selectedSearchBar: string;
 	setMiniBarIsClicked: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const GNB = ({
 	isLocationSearch,
 	miniBarIsClicked,
-	miniSearchBarIsHidden,
+	selectedSearchBar,
 	setMiniBarIsClicked,
 }: IGNBProps) => {
 	const GNBNav = (
@@ -44,7 +44,7 @@ const GNB = ({
 	);
 	const MiniBar = (
 		<MiniSearchBar
-			miniSearchBarIsHidden={miniSearchBarIsHidden}
+			selectedSearchBar={selectedSearchBar}
 			miniBarIsClicked={miniBarIsClicked}
 			setMiniBarIsClicked={setMiniBarIsClicked}
 		/>

--- a/src/Component/Header/GNB/GNB.tsx
+++ b/src/Component/Header/GNB/GNB.tsx
@@ -1,7 +1,8 @@
+import React from "react";
 import { Link } from "react-router-dom";
-
 import { AccountButton, MenuButton } from "util/Icons";
 import { StyledGNB, StyledNavList, GNBImg, GNBAccountMenu, StyledGNBNav } from "./GNB.styled";
+import MiniSearchBar from "../SearchBar/MiniSearchBar/MiniSearchBar";
 
 type listItem = {
 	id: number;
@@ -18,7 +19,7 @@ const navListItems: listItem[] = [
 	{ id: 3, name: "온라인 체험" },
 ];
 
-const GNBNav = ({ listItems }: GNBNavPropsType) => {
+const GNBNavLists = ({ listItems }: GNBNavPropsType) => {
 	const navList = listItems.map((item: listItem) => <li key={item.id}>{item.name}</li>);
 	return <StyledNavList>{navList}</StyledNavList>;
 };
@@ -26,18 +27,37 @@ const GNBNav = ({ listItems }: GNBNavPropsType) => {
 interface IGNBProps {
 	isLocationSearch: boolean;
 	miniBarIsClicked: boolean;
+	miniSearchBarIsHidden: boolean;
+	setMiniBarIsClicked: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const GNB = ({ isLocationSearch, miniBarIsClicked }: IGNBProps) => {
+const GNB = ({
+	isLocationSearch,
+	miniBarIsClicked,
+	miniSearchBarIsHidden,
+	setMiniBarIsClicked,
+}: IGNBProps) => {
+	const GNBNav = (
+		<StyledGNBNav isLocationSearch={isLocationSearch} miniBarIsClicked={miniBarIsClicked}>
+			<GNBNavLists listItems={navListItems} />
+		</StyledGNBNav>
+	);
+	const MiniBar = (
+		<MiniSearchBar
+			miniSearchBarIsHidden={miniSearchBarIsHidden}
+			miniBarIsClicked={miniBarIsClicked}
+			setMiniBarIsClicked={setMiniBarIsClicked}
+		/>
+	);
+
+	const GNBNavOrMiniBar = isLocationSearch && !miniBarIsClicked ? MiniBar : GNBNav;
+
 	return (
 		<StyledGNB>
 			<Link to="/">
 				<GNBImg />
 			</Link>
-			<StyledGNBNav isLocationSearch={isLocationSearch} miniBarIsClicked={miniBarIsClicked}>
-				<GNBNav listItems={navListItems} />
-			</StyledGNBNav>
-
+			{GNBNavOrMiniBar}
 			<GNBAccountMenu>
 				<MenuButton colorset="grey2" size={16} />
 				<AccountButton colorset="grey2" size={16} />

--- a/src/Component/Header/Header.styled.tsx
+++ b/src/Component/Header/Header.styled.tsx
@@ -36,7 +36,7 @@ const StyledSearchBarWrapper = styled.div<IStyledSearchBarWrapper>`
 			  `
 			: css`
 					height: 100px;
-					animation-duration: 1s;
+					animation-duration: 0.7s;
 					animation-name: close;
 					animation-fill-mode: forwards;
 					transition-timing-function: ease-out;
@@ -49,6 +49,7 @@ const StyledSearchBarWrapper = styled.div<IStyledSearchBarWrapper>`
 			box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5), 0px 2px 4px rgba(0, 0, 0, 0.25);
 			position: absolute;
 			top: 0;
+			background: white;
 		`}
 	
 
@@ -71,4 +72,12 @@ const StyledSearchBarWrapper = styled.div<IStyledSearchBarWrapper>`
 	}
 `;
 
-export { HeaderBackgroundImg, StyledSearchBarWrapper };
+const HeaderBackground = styled.div`
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	left: 0;
+	top: 0;
+`;
+
+export { HeaderBackgroundImg, StyledSearchBarWrapper, HeaderBackground };

--- a/src/Component/Header/Header.styled.tsx
+++ b/src/Component/Header/Header.styled.tsx
@@ -10,6 +10,10 @@ interface IStyledSearchBarWrapper {
 	isLocationSearch: boolean;
 }
 
+interface IHeaderBackground {
+	isLocationSearch: boolean;
+}
+
 const HeaderBackgroundImg = styled.div<IHeaderBackgroundImgn>`
 	${({ theme: { height, width }, image, isLocationSearch }) =>
 		isLocationSearch === false
@@ -72,12 +76,18 @@ const StyledSearchBarWrapper = styled.div<IStyledSearchBarWrapper>`
 	}
 `;
 
-const HeaderBackground = styled.div`
+const HeaderBackground = styled.div<IHeaderBackground>`
 	width: 100%;
 	height: 100%;
 	position: absolute;
 	left: 0;
 	top: 0;
+
+	${({ isLocationSearch }) =>
+		isLocationSearch &&
+		css`
+			z-index: 1;
+		`}
 `;
 
 export { HeaderBackgroundImg, StyledSearchBarWrapper, HeaderBackground };

--- a/src/Component/Header/Header.tsx
+++ b/src/Component/Header/Header.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { useLocation } from "react-router-dom";
+import { ModalContext, CheckModalContext } from "Context";
 import { HeaderBackgroundImg, StyledSearchBarWrapper, HeaderBackground } from "./Header.styled";
 import GNB from "./GNB/GNB";
 import SearchBar from "./SearchBar/SearchBar";
-import MiniSearchBar from "./SearchBar/MiniSearchBar/MiniSearchBar";
 import Modal from "./Modal/Modal";
 import coverSrc from "../../img/airbnb.png";
 
@@ -12,6 +12,9 @@ const Header = () => {
 	const [miniSearchBarIsHidden, setMiniSearchBarIsHidden] = useState(false);
 	const [searchBarIsHidden, setSearchBarIsHidden] = useState(false);
 	const [miniBarIsClicked, setMiniBarIsClicked] = useState(false);
+
+	const modal = useContext(ModalContext);
+	const checkModal = useContext(CheckModalContext);
 
 	const { pathname } = useLocation();
 	const isLocationSearch = pathname === "/search";
@@ -37,25 +40,26 @@ const Header = () => {
 		}
 	}, [miniBarIsClicked]);
 
-	const handleSearchBarAnimation = () => {
+	const handleModalMiniBar = () => {
+		if (modal !== "empty") checkModal("empty");
 		if (miniBarIsClicked) {
 			setMiniBarIsClicked(false);
 		}
 	};
 
 	return (
-		<HeaderBackground onClick={handleSearchBarAnimation}>
+		<HeaderBackground onClick={handleModalMiniBar} isLocationSearch={isLocationSearch}>
 			<HeaderBackgroundImg image={bgImage} isLocationSearch={isLocationSearch}>
-				<GNB isLocationSearch={isLocationSearch} miniBarIsClicked={miniBarIsClicked} />
+				<GNB
+					isLocationSearch={isLocationSearch}
+					miniBarIsClicked={miniBarIsClicked}
+					miniSearchBarIsHidden={miniSearchBarIsHidden}
+					setMiniBarIsClicked={setMiniBarIsClicked}
+				/>
 				<StyledSearchBarWrapper
 					isLocationSearch={isLocationSearch}
 					miniBarIsClicked={miniBarIsClicked}
 				>
-					<MiniSearchBar
-						miniSearchBarIsHidden={miniSearchBarIsHidden}
-						miniBarIsClicked={miniBarIsClicked}
-						setMiniBarIsClicked={setMiniBarIsClicked}
-					/>
 					<SearchBar
 						isLocationSearch={isLocationSearch}
 						searchBarIsHidden={searchBarIsHidden}

--- a/src/Component/Header/Header.tsx
+++ b/src/Component/Header/Header.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { HeaderBackgroundImg, StyledSearchBarWrapper } from "./Header.styled";
+import { HeaderBackgroundImg, StyledSearchBarWrapper, HeaderBackground } from "./Header.styled";
 import GNB from "./GNB/GNB";
 import SearchBar from "./SearchBar/SearchBar";
 import MiniSearchBar from "./SearchBar/MiniSearchBar/MiniSearchBar";
@@ -37,22 +37,36 @@ const Header = () => {
 		}
 	}, [miniBarIsClicked]);
 
+	const handleSearchBarAnimation = () => {
+		if (miniBarIsClicked) {
+			setMiniBarIsClicked(false);
+		}
+	};
+
 	return (
-		<HeaderBackgroundImg image={bgImage} isLocationSearch={isLocationSearch}>
-			<GNB isLocationSearch={isLocationSearch} miniBarIsClicked={miniBarIsClicked} />
-			<StyledSearchBarWrapper
-				isLocationSearch={isLocationSearch}
-				miniBarIsClicked={miniBarIsClicked}
-			>
-				<MiniSearchBar
-					miniSearchBarIsHidden={miniSearchBarIsHidden}
+		<HeaderBackground onClick={handleSearchBarAnimation}>
+			<HeaderBackgroundImg image={bgImage} isLocationSearch={isLocationSearch}>
+				<GNB isLocationSearch={isLocationSearch} miniBarIsClicked={miniBarIsClicked} />
+				<StyledSearchBarWrapper
+					isLocationSearch={isLocationSearch}
 					miniBarIsClicked={miniBarIsClicked}
-					setMiniBarIsClicked={setMiniBarIsClicked}
-				/>
-				<SearchBar searchBarIsHidden={searchBarIsHidden} miniBarIsClicked={miniBarIsClicked} />
-			</StyledSearchBarWrapper>
-			<Modal />
-		</HeaderBackgroundImg>
+				>
+					<MiniSearchBar
+						miniSearchBarIsHidden={miniSearchBarIsHidden}
+						miniBarIsClicked={miniBarIsClicked}
+						setMiniBarIsClicked={setMiniBarIsClicked}
+					/>
+					<SearchBar
+						isLocationSearch={isLocationSearch}
+						searchBarIsHidden={searchBarIsHidden}
+						miniBarIsClicked={miniBarIsClicked}
+						setSearchBarIsHidden={setSearchBarIsHidden}
+						setMiniSearchBarIsHidden={setMiniSearchBarIsHidden}
+					/>
+				</StyledSearchBarWrapper>
+				<Modal />
+			</HeaderBackgroundImg>
+		</HeaderBackground>
 	);
 };
 

--- a/src/Component/Header/Header.tsx
+++ b/src/Component/Header/Header.tsx
@@ -9,9 +9,8 @@ import coverSrc from "../../img/airbnb.png";
 
 const Header = () => {
 	const [bgImage, setBgImage] = useState(null);
-	const [miniSearchBarIsHidden, setMiniSearchBarIsHidden] = useState(false);
-	const [searchBarIsHidden, setSearchBarIsHidden] = useState(false);
 	const [miniBarIsClicked, setMiniBarIsClicked] = useState(false);
+	const [selectedSearchBar, setSelectedSearchBar] = useState("searchBar");
 
 	const modal = useContext(ModalContext);
 	const checkModal = useContext(CheckModalContext);
@@ -25,18 +24,15 @@ const Header = () => {
 
 	useEffect(() => {
 		if (isLocationSearch) {
-			setMiniSearchBarIsHidden(false);
-			setSearchBarIsHidden(true);
+			setSelectedSearchBar("miniSearchBar");
 		} else {
-			setMiniSearchBarIsHidden(true);
-			setSearchBarIsHidden(false);
+			setSelectedSearchBar("searchBar");
 		}
 	}, [pathname]);
 
 	useEffect(() => {
 		if (miniBarIsClicked) {
-			setMiniSearchBarIsHidden(true);
-			setSearchBarIsHidden(false);
+			setSelectedSearchBar("searchBar");
 		}
 	}, [miniBarIsClicked]);
 
@@ -53,7 +49,7 @@ const Header = () => {
 				<GNB
 					isLocationSearch={isLocationSearch}
 					miniBarIsClicked={miniBarIsClicked}
-					miniSearchBarIsHidden={miniSearchBarIsHidden}
+					selectedSearchBar={selectedSearchBar}
 					setMiniBarIsClicked={setMiniBarIsClicked}
 				/>
 				<StyledSearchBarWrapper
@@ -62,10 +58,9 @@ const Header = () => {
 				>
 					<SearchBar
 						isLocationSearch={isLocationSearch}
-						searchBarIsHidden={searchBarIsHidden}
 						miniBarIsClicked={miniBarIsClicked}
-						setSearchBarIsHidden={setSearchBarIsHidden}
-						setMiniSearchBarIsHidden={setMiniSearchBarIsHidden}
+						selectedSearchBar={selectedSearchBar}
+						setSelectedSearchBar={setSelectedSearchBar}
 					/>
 				</StyledSearchBarWrapper>
 				<Modal />

--- a/src/Component/Header/Modal/Modal.styled.tsx
+++ b/src/Component/Header/Modal/Modal.styled.tsx
@@ -41,6 +41,9 @@ const StyledModal = styled.div<IStyleModal>`
 		overflow: hidden;
 	`}
 	box-sizing: border-box;
+
+	position: relative;
+	z-index: 2;
 `;
 
 const StyledGuestList = styled.li`

--- a/src/Component/Header/SearchBar/Guest/Guest.tsx
+++ b/src/Component/Header/SearchBar/Guest/Guest.tsx
@@ -17,7 +17,7 @@ const Guest = () => {
 	const reset = () => guestsDispatch({ guest: "adult", type: "reset" });
 
 	return (
-		<StyledGuestHover>
+		<StyledGuestHover onClick={(event) => event.stopPropagation()}>
 			<StyledGuest>
 				<StyledSearchBarChild onClick={() => checkModal(modalState)} name={modalState}>
 					<div>인원</div>

--- a/src/Component/Header/SearchBar/MiniSearchBar/MiniSearchBar.styled.tsx
+++ b/src/Component/Header/SearchBar/MiniSearchBar/MiniSearchBar.styled.tsx
@@ -20,10 +20,10 @@ const StyledMiniSearchBar = styled.div<IStyledMiniSearchBar>`
 
 	width: 410px;
 	height: 48px;
-	margin: 0 auto;
-	position: absolute;
-	top: 30px;
-	left: 36%;
+	/* margin: 0 auto; */
+	/* position: absolute; */
+	/* top: 30px; */
+	/* left: 36%; */
 	text-align: center;
 	background: #ffffff;
 	border: 1px solid #bdbdbd;

--- a/src/Component/Header/SearchBar/MiniSearchBar/MiniSearchBar.styled.tsx
+++ b/src/Component/Header/SearchBar/MiniSearchBar/MiniSearchBar.styled.tsx
@@ -5,12 +5,12 @@ interface IStyledMiniSearchBarChild {
 }
 
 interface IStyledMiniSearchBar {
-	miniSearchBarIsHidden: boolean;
+	selectedSearchBar: string;
 }
 
 const StyledMiniSearchBar = styled.div<IStyledMiniSearchBar>`
-	${({ miniSearchBarIsHidden }) =>
-		miniSearchBarIsHidden
+	${({ selectedSearchBar }) =>
+		selectedSearchBar === "searchBar"
 			? css`
 					visibility: hidden;
 			  `
@@ -20,10 +20,6 @@ const StyledMiniSearchBar = styled.div<IStyledMiniSearchBar>`
 
 	width: 410px;
 	height: 48px;
-	/* margin: 0 auto; */
-	/* position: absolute; */
-	/* top: 30px; */
-	/* left: 36%; */
 	text-align: center;
 	background: #ffffff;
 	border: 1px solid #bdbdbd;

--- a/src/Component/Header/SearchBar/MiniSearchBar/MiniSearchBar.tsx
+++ b/src/Component/Header/SearchBar/MiniSearchBar/MiniSearchBar.tsx
@@ -1,19 +1,18 @@
 import React from "react";
 import { SearchButton } from "util/Icons";
 import { StyledMiniSearchBar, SearchIcon } from "./MiniSearchBar.styled";
-
 import MiniSchedule from "./MiniSchedule/MiniSchedule";
 import MiniPrice from "./MiniPrice/MiniPrice";
 import MiniGuest from "./MiniGuest/MiniGuest";
 
 interface IMiniSearchBarProps {
-	miniSearchBarIsHidden: boolean;
+	selectedSearchBar: string;
 	miniBarIsClicked: boolean;
 	setMiniBarIsClicked: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const MiniSearchBar = ({
-	miniSearchBarIsHidden,
+	selectedSearchBar,
 	miniBarIsClicked,
 	setMiniBarIsClicked,
 }: IMiniSearchBarProps) => {
@@ -22,10 +21,7 @@ const MiniSearchBar = ({
 	};
 
 	return (
-		<StyledMiniSearchBar
-			miniSearchBarIsHidden={miniSearchBarIsHidden}
-			onClick={handleMiniBarIsClicked}
-		>
+		<StyledMiniSearchBar selectedSearchBar={selectedSearchBar} onClick={handleMiniBarIsClicked}>
 			<MiniSchedule />
 			<MiniPrice />
 			<MiniGuest />

--- a/src/Component/Header/SearchBar/Price/Price.tsx
+++ b/src/Component/Header/SearchBar/Price/Price.tsx
@@ -17,7 +17,7 @@ const Price = () => {
 	const isDefault = max === 1000000 && min === 0;
 
 	return (
-		<StyledPriceHover>
+		<StyledPriceHover onClick={(event) => event.stopPropagation()}>
 			<StyledPrice>
 				<StyledSearchBarChild onClick={() => checkModal(modalState)} name={modalState}>
 					<div>{PRICE}</div>

--- a/src/Component/Header/SearchBar/Schedule/Schedule.tsx
+++ b/src/Component/Header/SearchBar/Schedule/Schedule.tsx
@@ -19,7 +19,7 @@ const Schedule = () => {
 
 	return (
 		<>
-			<StyledCheckin>
+			<StyledCheckin onClick={(event) => event.stopPropagation()}>
 				<StyledSearchBarChild onClick={() => checkModal(modalStateCheckin)} name={name}>
 					<div>체크인</div>
 					<div>
@@ -37,7 +37,7 @@ const Schedule = () => {
 					/>
 				)}
 			</StyledCheckin>
-			<StyledCheckout>
+			<StyledCheckout onClick={(event) => event.stopPropagation()}>
 				<StyledSearchBarChild onClick={() => checkModal(modalStateCheckout)} name={name}>
 					<div>체크아웃</div>
 					<div>

--- a/src/Component/Header/SearchBar/SearchBar.styled.tsx
+++ b/src/Component/Header/SearchBar/SearchBar.styled.tsx
@@ -7,7 +7,13 @@ interface IStyledSearchBarChild {
 interface IStyledSearchBar {
 	searchBarIsHidden: boolean;
 	miniBarIsClicked: boolean;
+	isLocationSearch: boolean;
 }
+
+const SearchBarWrapper = styled.div`
+	width: 100%;
+	margin: 0 auto;
+`;
 
 const StyledSearchBar = styled.div<IStyledSearchBar>`
 	${({ searchBarIsHidden }) =>
@@ -31,19 +37,37 @@ const StyledSearchBar = styled.div<IStyledSearchBar>`
 		background-color: ${colors.white};
 	`}
 
-	${({ miniBarIsClicked }) =>
+	${({ miniBarIsClicked, isLocationSearch }) =>
 		miniBarIsClicked &&
+		isLocationSearch &&
 		css`
-			position: absolute;
-			top: 30px;
-			left: 21%;
+			// position: absolute;
+			// top: 70px;
+			// left: 21%;
+			margin: 0 auto;
+			margin-top: 130px;
 			animation-duration: 1s;
-			animation-name: slide;
+			animation-name: slide-out;
 			animation-fill-mode: forwards;
 			transition-timing-function: ease-out;
 		`}}
 
-		@keyframes slide {
+		${({ miniBarIsClicked, isLocationSearch }) =>
+			!miniBarIsClicked &&
+			isLocationSearch &&
+			css`
+				// position: absolute;
+				// top: 70px;
+				margin: 0 auto;
+				margin-top: 130px;
+				// left: 21%;
+				animation-duration: 0.6s;
+				animation-name: slide-in;
+				animation-fill-mode: forwards;
+				transition-timing-function: ease-out;
+			`}}
+
+		@keyframes slide-out{
 			from {
 				margin-top: 23px;
 				transform: scale(0.5);
@@ -53,6 +77,21 @@ const StyledSearchBar = styled.div<IStyledSearchBar>`
 				transform: scale(1.0);
 			}
 		}
+
+		@keyframes slide-in{
+			from {
+				margin-top: 90px;
+				transform: scale(1.0);
+			}
+			to {
+				margin-top: -10px; 
+				transform: scale(0.4); 
+			}
+		}
+
+
+		
+
 	z-index: 10;
 `;
 
@@ -101,4 +140,4 @@ const SearchIcon = styled.div`
 	z-index: 10;
 `;
 
-export { StyledSearchBar, StyledSearchBarChild, SearchIcon };
+export { StyledSearchBar, StyledSearchBarChild, SearchIcon, SearchBarWrapper };

--- a/src/Component/Header/SearchBar/SearchBar.styled.tsx
+++ b/src/Component/Header/SearchBar/SearchBar.styled.tsx
@@ -5,7 +5,7 @@ interface IStyledSearchBarChild {
 }
 
 interface IStyledSearchBar {
-	searchBarIsHidden: boolean;
+	selectedSearchBar: string;
 	miniBarIsClicked: boolean;
 	isLocationSearch: boolean;
 }
@@ -16,8 +16,8 @@ const SearchBarWrapper = styled.div`
 `;
 
 const StyledSearchBar = styled.div<IStyledSearchBar>`
-	${({ searchBarIsHidden }) =>
-		searchBarIsHidden
+	${({ selectedSearchBar }) =>
+		selectedSearchBar === "miniSearchBar"
 			? css`
 					visibility: hidden;
 			  `

--- a/src/Component/Header/SearchBar/SearchBar.styled.tsx
+++ b/src/Component/Header/SearchBar/SearchBar.styled.tsx
@@ -41,9 +41,6 @@ const StyledSearchBar = styled.div<IStyledSearchBar>`
 		miniBarIsClicked &&
 		isLocationSearch &&
 		css`
-			// position: absolute;
-			// top: 70px;
-			// left: 21%;
 			margin: 0 auto;
 			margin-top: 130px;
 			animation-duration: 1s;
@@ -56,11 +53,8 @@ const StyledSearchBar = styled.div<IStyledSearchBar>`
 			!miniBarIsClicked &&
 			isLocationSearch &&
 			css`
-				// position: absolute;
-				// top: 70px;
 				margin: 0 auto;
 				margin-top: 130px;
-				// left: 21%;
 				animation-duration: 0.6s;
 				animation-name: slide-in;
 				animation-fill-mode: forwards;
@@ -84,8 +78,8 @@ const StyledSearchBar = styled.div<IStyledSearchBar>`
 				transform: scale(1.0);
 			}
 			to {
-				margin-top: -10px; 
-				transform: scale(0.4); 
+				margin-top: 17px; 
+				transform: scale(0.5); 
 			}
 		}
 

--- a/src/Component/Header/SearchBar/SearchBar.tsx
+++ b/src/Component/Header/SearchBar/SearchBar.tsx
@@ -8,19 +8,17 @@ import Price from "./Price/Price";
 import Guest from "./Guest/Guest";
 
 interface ISearchBarProps {
-	searchBarIsHidden: boolean;
 	miniBarIsClicked: boolean;
 	isLocationSearch: boolean;
-	setSearchBarIsHidden: React.Dispatch<React.SetStateAction<boolean>>;
-	setMiniSearchBarIsHidden: React.Dispatch<React.SetStateAction<boolean>>;
+	selectedSearchBar: string;
+	setSelectedSearchBar: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const SearchBar = ({
-	searchBarIsHidden,
 	miniBarIsClicked,
 	isLocationSearch,
-	setSearchBarIsHidden,
-	setMiniSearchBarIsHidden,
+	selectedSearchBar,
+	setSelectedSearchBar,
 }: ISearchBarProps) => {
 	const modal = useContext(ModalContext);
 	const checkModal = useContext(CheckModalContext);
@@ -31,8 +29,7 @@ const SearchBar = ({
 
 	const handleOnAnimationEnd = () => {
 		if (!miniBarIsClicked) {
-			setSearchBarIsHidden(true);
-			setMiniSearchBarIsHidden(false);
+			setSelectedSearchBar("miniSearchBar");
 		}
 	};
 
@@ -40,7 +37,7 @@ const SearchBar = ({
 		<SearchBarWrapper>
 			<StyledSearchBar
 				isLocationSearch={isLocationSearch}
-				searchBarIsHidden={searchBarIsHidden}
+				selectedSearchBar={selectedSearchBar}
 				miniBarIsClicked={miniBarIsClicked}
 				onAnimationEnd={handleOnAnimationEnd}
 			>

--- a/src/Component/Header/SearchBar/SearchBar.tsx
+++ b/src/Component/Header/SearchBar/SearchBar.tsx
@@ -1,18 +1,27 @@
 import { Link } from "react-router-dom";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { ModalContext, CheckModalContext } from "Context";
 import { SearchButton } from "util/Icons";
 import Schedule from "./Schedule/Schedule";
-import { StyledSearchBar, SearchIcon } from "./SearchBar.styled";
+import { StyledSearchBar, SearchIcon, SearchBarWrapper } from "./SearchBar.styled";
 import Price from "./Price/Price";
 import Guest from "./Guest/Guest";
 
 interface ISearchBarProps {
 	searchBarIsHidden: boolean;
 	miniBarIsClicked: boolean;
+	isLocationSearch: boolean;
+	setSearchBarIsHidden: React.Dispatch<React.SetStateAction<boolean>>;
+	setMiniSearchBarIsHidden: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const SearchBar = ({ searchBarIsHidden, miniBarIsClicked }: ISearchBarProps) => {
+const SearchBar = ({
+	searchBarIsHidden,
+	miniBarIsClicked,
+	isLocationSearch,
+	setSearchBarIsHidden,
+	setMiniSearchBarIsHidden,
+}: ISearchBarProps) => {
 	const modal = useContext(ModalContext);
 	const checkModal = useContext(CheckModalContext);
 
@@ -20,18 +29,32 @@ const SearchBar = ({ searchBarIsHidden, miniBarIsClicked }: ISearchBarProps) => 
 		if (modal !== "empty") checkModal("empty");
 	};
 
+	const handleOnAnimationEnd = () => {
+		if (!miniBarIsClicked) {
+			setSearchBarIsHidden(true);
+			setMiniSearchBarIsHidden(false);
+		}
+	};
+
 	return (
-		<StyledSearchBar searchBarIsHidden={searchBarIsHidden} miniBarIsClicked={miniBarIsClicked}>
-			<Schedule />
-			<Price />
-			<Guest />
-			<Link to="search">
-				<SearchIcon onClick={handleModalPopup}>
-					<SearchButton colorset="white" size={30} />
-					<div>검색</div>
-				</SearchIcon>
-			</Link>
-		</StyledSearchBar>
+		<SearchBarWrapper>
+			<StyledSearchBar
+				isLocationSearch={isLocationSearch}
+				searchBarIsHidden={searchBarIsHidden}
+				miniBarIsClicked={miniBarIsClicked}
+				onAnimationEnd={handleOnAnimationEnd}
+			>
+				<Schedule />
+				<Price />
+				<Guest />
+				<Link to="search">
+					<SearchIcon onClick={handleModalPopup}>
+						<SearchButton colorset="white" size={30} />
+						<div>검색</div>
+					</SearchIcon>
+				</Link>
+			</StyledSearchBar>
+		</SearchBarWrapper>
 	);
 };
 

--- a/src/Component/SearchDesc/SearchDesc.styled.tsx
+++ b/src/Component/SearchDesc/SearchDesc.styled.tsx
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 
 const SearchDescWrapper = styled.div`
 	margin: 0 auto;
+	margin-top: 120px;
 	display: flex;
 	${({ theme: { width } }) => css`
 		width: ${width.header};


### PR DESCRIPTION
## DESCRIPTION

- 헤더가 늘어났을 경우 헤더 외부 클릭 시 원래 사이즈로 줄어듦
-  서치바에서 미니바로 변경 시 slide-in 애니메이션을 추가
   - **TODO**: slide-in 애니메이션에 `onAnimationEnd`를 적용해 미니바와 서치바를 변경했는데 부자연스러움 
- 미니바를 Header 컴포넌트에서 GNB 컴포넌트로 이동 
  - 원래 Header 컴포넌트에 SearchBar 컴포넌트와 동일한 계층으로 있었음 
  - 상태에 따라 GNBNav 와 GNB 를 선택해 렌더링하는 구조로 변경 
  - _**Background 와 HeaderBackground 가 가지고 있는 `position:absolute` 로 인해 `z-index` 를 isLocationSearch 상태에 따라 변경해줌**_ 
- miniSearchBarIsHidden 과 searchBarisHidden 상태 두 개를 selectedSearchBar 상태 하나로 통합 
  - miniSearchBarIsHidden 과 searchBarisHidden 이 반대되는 상태를 가졌었음 

## VIEW
![Jun-09-2022 23-42-30](https://user-images.githubusercontent.com/68533016/172876781-76f05b56-d088-49c2-ab84-dd3506703bf5.gif)



